### PR TITLE
Fix linking breakage in tests

### DIFF
--- a/benchmarks/usr/xio_perftest/xio_msg.c
+++ b/benchmarks/usr/xio_perftest/xio_msg.c
@@ -115,7 +115,7 @@ failed_huge_page:
 /*---------------------------------------------------------------------------*/
 /* free_mem_buf								     */
 /*---------------------------------------------------------------------------*/
-inline void free_mem_buf(uint8_t *pool_buf, int shmid)
+static inline void free_mem_buf(uint8_t *pool_buf, int shmid)
 {
 	if (shmid >= 0) {
 		if (shmdt(pool_buf) != 0) {
@@ -233,4 +233,3 @@ void  xio_buf_free(struct perf_buf *pbuf)
 
 	free(pbuf);
 }
-

--- a/tests/usr/common/xio_msg.c
+++ b/tests/usr/common/xio_msg.c
@@ -117,7 +117,7 @@ failed_huge_page:
 /*---------------------------------------------------------------------------*/
 /* free_mem_buf								     */
 /*---------------------------------------------------------------------------*/
-inline void free_mem_buf(void *pool_buf, int shmid)
+static inline void free_mem_buf(void *pool_buf, int shmid)
 {
 	if (shmid >= 0) {
 		if (shmdt(pool_buf) != 0) {
@@ -342,4 +342,3 @@ inline void msg_pool_free(struct msg_pool *pool)
 	if (pool)
 		free(pool);
 }
-


### PR DESCRIPTION
Compilation / linking with clang bumps into this:
```
libtool: link: /usr/local/bin/clang -DPIC -fPIC -I../../../../git/include -g -ggdb -Wall -Werror -Wdeclaration-after-statement -Wsign-compare -Wc++-compat -fno-omit-frame-pointer -O0 -D_REENTRANT -D_GNU_SOURCE -DXIO_CFLAG_EXTRA_CHECKS -DXIO_CFLAG_STAT_COUNTERS -DVERB_READ -DTEST_LAT -fsanitize=address,undefined -fno-omit-frame-pointer -Wno-address-of-packed-member -Wno-unused-function -o .libs/xio_read_lat xio_read_lat-xio_msg.o xio_read_lat-xio_perftest_client.o xio_read_lat-xio_perftest_server.o xio_read_lat-xio_perftest_parameters.o xio_read_lat-xio_perftest_communication.o xio_read_lat-xio_perftest.o xio_read_lat-get_clock.o  /home/arne/Projects/openvstorage/accelio/build/src/usr/.libs/libxio.so -lrdmacm -libverbs -lrt -lpthread -L../../../src/usr/ -lnuma
xio_read_lat-xio_msg.o: In function `xio_buf_free':
/home/arne/Projects/openvstorage/accelio/build/benchmarks/usr/xio_perftest/../../../../git/benchmarks/usr/xio_perftest/xio_msg.c:232: undefined reference to `free_mem_buf'
```