### PR TITLE
Fix xio_general_set_opt(XIO_OPTNAME_SND_QUEUE_DEPTH_MSGS)

### DIFF
--- a/src/common/xio_options.c
+++ b/src/common/xio_options.c
@@ -214,7 +214,7 @@ static int xio_general_set_opt(void *xio_obj, int optname,
 	case XIO_OPTNAME_SND_QUEUE_DEPTH_MSGS:
 		if (*((int *)optval) < 1)
 			break;
-		g_options.snd_queue_depth_msgs = (int)*((uint64_t *)optval);
+		g_options.snd_queue_depth_msgs = *((int *)optval);
 		return 0;
 	case XIO_OPTNAME_RCV_QUEUE_DEPTH_MSGS:
 		if (*((int *)optval) < 1)


### PR DESCRIPTION
ASan points out a stack overflow as the "optval" int is reinterpreted as a
uint64_t.
```
==3475==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fe67f4e2ee0 at pc 0x7fe6add6a1d4 bp 0x7fe67f4e2aa0 sp 0x7fe67f4e2a98
READ of size 8 at 0x7fe67f4e2ee0 thread T67 (xio_server)
    #0 0x7fe6add6a1d3 in xio_general_set_opt /home/jenkins/accelio/src/usr/../common/xio_options.c:217:41
    #1 0x7fe6add6886a in xio_set_opt /home/jenkins/accelio/src/usr/../common/xio_options.c:392:10
    [...]

Address 0x7fe67f4e2ee0 is located in stack of thread T67 (xio_server) at offset 32 in frame
    #0 0x24979bf in volumedriverfs::NetworkXioServer::run(std::promise<void>) /home/jenkins/volumedriver-ee/src/filesystem/NetworkXioServer.cpp:153

  This frame has 65 object(s):
    [32, 36) 'xopt' (line 154) <== Memory access at offset 32 partially overflows this variable
    [...]
```