### PR TITLE
Fix keepalive

### DIFF
--- a/src/common/xio_connection.c
+++ b/src/common/xio_connection.c
@@ -3271,9 +3271,14 @@ void xio_connection_keepalive_intvl(void *_connection)
 			ERROR_LOG("periodic keepalive failed - abort\n");
 			return;
 		}
+
+		/* notify the transport via the nexus */
+		xio_nexus_keepalive_timeout(connection->nexus);
+
 		/* notify the application of connection error */
 		xio_session_notify_connection_error(
 				connection->session, connection, XIO_E_TIMEOUT);
+
 		if ((!connection->disconnecting) && (!g_options.reconnect))
 			xio_disconnect(connection);
 		return;
@@ -3340,4 +3345,3 @@ void xio_connection_keepalive_start(void *_connection)
 		return;
 	}
 }
-

--- a/src/common/xio_nexus.c
+++ b/src/common/xio_nexus.c
@@ -2686,3 +2686,14 @@ void xio_nexus_set_server(struct xio_nexus *nexus, struct xio_server *server)
 	if (server)
 		xio_server_reg_observer(server, &nexus->srv_observer);
 }
+
+/*---------------------------------------------------------------------------*/
+/* xio_nexus_keepalive_timeout						     */
+/*---------------------------------------------------------------------------*/
+void xio_nexus_keepalive_timeout(struct xio_nexus *nexus)
+{
+	if (nexus->transport->keepalive_timeout)
+		nexus->transport->keepalive_timeout(nexus->transport_hndl);
+	else
+		ERROR_LOG("transport cannot be notified of keepalive timeout");
+}

--- a/src/common/xio_nexus.h
+++ b/src/common/xio_nexus.h
@@ -381,6 +381,11 @@ int xio_nexus_query(struct xio_nexus *nexus,
 		    struct xio_nexus_attr *attr,
 		    int attr_mask);
 
+/*---------------------------------------------------------------------------*/
+/* xio_nexus_keepalive_timeout						     */
+/*---------------------------------------------------------------------------*/
+void xio_nexus_keepalive_timeout(struct xio_nexus *nexus);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/xio_session.c
+++ b/src/common/xio_session.c
@@ -1271,8 +1271,9 @@ int xio_on_nexus_error(struct xio_session *session, struct xio_nexus *nexus,
 		break;
 	default:
 		connection = xio_session_find_connection(session, nexus);
-		xio_connection_error_event(connection,
-					   event_data->error.reason);
+		if (connection)
+			xio_connection_error_event(connection,
+						   event_data->error.reason);
 		break;
 	}
 
@@ -2083,4 +2084,3 @@ void xio_session_init_teardown(struct xio_session *session,
 				xio_session_pre_teardown,
 				&session->teardown_work);
 }
-

--- a/src/common/xio_transport.h
+++ b/src/common/xio_transport.h
@@ -270,6 +270,8 @@ struct xio_transport {
 			 struct xio_transport_attr *attr,
 			 int attr_mask);
 
+	void	(*keepalive_timeout)(struct xio_transport_base *trans_hndl);
+
 	struct list_head transports_list_entry;
 };
 

--- a/src/usr/transport/tcp/xio_tcp_management.c
+++ b/src/usr/transport/tcp/xio_tcp_management.c
@@ -2636,6 +2636,24 @@ static int xio_tcp_dup2(struct xio_transport_base *old_trans_hndl,
 }
 
 /*---------------------------------------------------------------------------*/
+/* xio_tcp_keepalive_timeout                                                 */
+/*---------------------------------------------------------------------------*/
+static void xio_tcp_keepalive_timeout(struct xio_transport_base *trans_hndl)
+{
+	struct xio_tcp_transport *tcp_hndl =
+		(struct xio_tcp_transport *)trans_hndl;
+
+	xio_context_disable_event(&tcp_hndl->flush_tx_event);
+	xio_context_disable_event(&tcp_hndl->ctl_rx_event);
+
+	if (tcp_hndl->sock.ops->del_ev_handlers)
+		tcp_hndl->sock.ops->del_ev_handlers(tcp_hndl);
+
+	xio_transport_notify_observer_error(trans_hndl,
+					    XIO_E_TIMEOUT);
+}
+
+/*---------------------------------------------------------------------------*/
 static void init_single_sock_ops(void)
 {
 	single_sock_ops.open = xio_tcp_single_sock_create;
@@ -2691,6 +2709,8 @@ static void init_xio_tcp_transport(void)
 	xio_tcp_transport.get_opt = xio_tcp_get_opt;
 	xio_tcp_transport.cancel_req = xio_tcp_cancel_req;
 	xio_tcp_transport.cancel_rsp = xio_tcp_cancel_rsp;
+	xio_tcp_transport.keepalive_timeout = xio_tcp_keepalive_timeout;
+
 	xio_tcp_transport.get_pools_setup_ops = xio_tcp_get_pools_ops;
 	xio_tcp_transport.set_pools_cls = xio_tcp_set_pools_cls;
 

--- a/src/usr/transport/tcp/xio_tcp_management.c
+++ b/src/usr/transport/tcp/xio_tcp_management.c
@@ -192,6 +192,8 @@ int xio_tcp_single_sock_del_ev_handlers(struct xio_tcp_transport *tcp_hndl)
 	if (retval) {
 		ERROR_LOG("tcp_hndl:%p fd=%d del_ev_handler failed, %m\n",
 			  tcp_hndl, tcp_hndl->sock.cfd);
+	} else {
+		tcp_hndl->in_epoll[0] = 0;
 	}
 
 	return retval;
@@ -211,7 +213,9 @@ int xio_tcp_dual_sock_del_ev_handlers(struct xio_tcp_transport *tcp_hndl)
                 if (retval1) {
                         ERROR_LOG("tcp_hndl:%p fd=%d del_ev_handler failed, %m\n",
                                   tcp_hndl, tcp_hndl->sock.cfd);
-                }
+                } else {
+			tcp_hndl->in_epoll[0] = 0;
+		}
         }
 	/* remove from epoll */
         if (tcp_hndl->in_epoll[1]) {
@@ -221,7 +225,9 @@ int xio_tcp_dual_sock_del_ev_handlers(struct xio_tcp_transport *tcp_hndl)
                 if (retval2) {
                         ERROR_LOG("tcp_hndl:%p fd=%d del_ev_handler failed, %m\n",
                                   tcp_hndl, tcp_hndl->sock.dfd);
-                }
+                }  else {
+			tcp_hndl->in_epoll[1] = 0;
+		}
         }
 
 	return retval1 | retval2;


### PR DESCRIPTION
Addresses #4 : the idea is to notify the transport layer of the keepalive timeout which in turn will stop further processing of events and notify its observers (only implemented for TCP at the moment).