### PR TITLE
accelio: clean uninitialized structure

### DIFF
--- a/src/common/xio_nexus.c
+++ b/src/common/xio_nexus.c
@@ -1569,7 +1569,7 @@ static int xio_nexus_on_assign_in_buf(struct xio_nexus *nexus,
 {
 	int				retval = 0;
 	struct xio_task			*task = event_data->msg.task;
-	union xio_nexus_event_data	nexus_event_data;
+	union xio_nexus_event_data	nexus_event_data = {};
 
 	nexus_event_data.assign_in_buf.task = event_data->msg.task;
 	task->nexus = nexus;


### PR DESCRIPTION
Cherry pick a changeset from the iguazio repo that properly initializes the `xio_nexus_event_data` in `xio_nexus_on_assign_in_buf` (possibly related to #11 ?)